### PR TITLE
Add sequential zipper

### DIFF
--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -127,8 +127,12 @@ def list_missing(split):
         else:
             return None
 
-    with ThreadPoolExecutor(max_workers=32) as executor:
-        missing_paths = list(tqdm.tqdm(executor.map(partial(check_path_exists, dataset), range(len(dataset))), total=len(dataset)))
+    # with ThreadPoolExecutor(max_workers=32) as executor:
+    #     missing_paths = list(tqdm.tqdm(executor.map(partial(check_path_exists, dataset), range(len(dataset))), total=len(dataset)))
+    missing_paths = []
+    for i in tqdm.tqdm(range(len(dataset))):
+        missing_paths.append(check_path_exists(dataset, i))
+        
 
     f = open(f"CGLM_{split}_missing_paths.txt", "w")
     

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -1,6 +1,6 @@
 import os
 from typing import Callable, Optional, Tuple
-
+import tqdm
 import h5py
 from PIL import Image
 
@@ -91,7 +91,7 @@ class H5Dataset(BaseDataClass):
         img_path = self.directory + '/data/' + \
             self.image_paths[index].decode("utf-8").strip()
         label = self.labels[index]
-        sample = pil_loader(img_path)
+        sample = Image.open(img_path)
 
         if self.transform is not None:
             sample = self.transform(sample)
@@ -108,18 +108,57 @@ class H5Dataset(BaseDataClass):
         return len(self.image_paths)
 
 
-def pil_loader(path: str) -> Image.Image:
-    # open path as file to avoid ResourceWarning (https://github.com/python-pillow/Pillow/issues/835)
-    with open(path, "rb") as f:
-        img = Image.open(f)
-        return img.convert("RGB")
+def list_missing(split):
+    dataset = H5Dataset(
+        dataset="CGLM",
+        directory="/export/work/cbotos/cldatasets/CGLM/",
+        partition=split,
+    )
+    print(len(dataset))
 
+    from concurrent.futures import ThreadPoolExecutor
+    from functools import partial
+
+    def check_path_exists(dataset, i):
+        if not os.path.exists(dataset.directory + '/data/' + dataset.image_paths[i].decode("utf-8").strip()):
+            return i, dataset.image_paths[i].decode("utf-8").strip()
+        elif dataset.image_paths[i].decode("utf-8").strip() == "":
+            return i, "<empty>"
+        else:
+            return None
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        missing_paths = list(tqdm.tqdm(executor.map(partial(check_path_exists, dataset), range(len(dataset))), total=len(dataset)))
+
+    f = open(f"CGLM_{split}_missing_paths.txt", "w")
+    
+    for i in missing_paths:
+        if i is not None:
+            print(f"{i[0]},{i[1]}", file=f)
+    
+    f.close()
+
+
+    
+    
 
 if __name__ == "__main__":
-    BaseDataClass(dataset='ImageNet2K',
-                  directory='/data/cl_datasets/files/ImageNet2K/')
+    # BaseDataClass(dataset='ImageNet2K',
+    #               directory='/data/cl_datasets/files/ImageNet2K/')
 
     dataset = H5Dataset(
         dataset='ImageNet2K', directory="/data/cl_datasets/files/ImageNet2K/", partition='data_inc')
-    print(len(dataset))
-    dataset[1][0].show()
+
+    for split in ['train', 'test', 'pretrain', 'pretest', 'preval', 'cls_inc', 'data_inc']:
+        print(split)
+        try:
+            list_missing(split)
+        except Exception as e:
+            print(e)
+            continue
+
+    # dataset = H5Dataset(
+    #     dataset="CLOC",
+    #     directory="/export/work/cbotos/cldatasets/CLOC/",
+    #     partition="train",
+    # )

--- a/src/list_missing.py
+++ b/src/list_missing.py
@@ -1,0 +1,52 @@
+from dataloader import H5Dataset
+from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor
+import os
+
+def list_missing(split):
+    dataset = H5Dataset(
+        dataset="CGLM",
+        directory="/export/work/cbotos/cldatasets/CGLM/",
+        partition=split,
+    )
+    print(len(dataset))
+
+    from functools import partial
+
+    def check_path_exists(dataset, start_idx, end_idx):
+        for i in tqdm(range(start_idx, end_idx), desc=f"Checking from {start_idx} to {end_idx}", leave=False):
+            if not os.path.exists(dataset.directory + '/data/' + dataset.image_paths[i].decode("utf-8").strip()):
+                raise Exception("Path not found", dataset.directory + '/data/' + dataset.image_paths[i].decode("utf-8").strip())
+        
+
+    missing_paths = []
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        futures_list = []
+        chunk_size = 1000
+        with tqdm(total=len(dataset)//chunk_size) as pbar:
+            for i in range(0, len(dataset), chunk_size):
+                future = executor.submit(check_path_exists, dataset, i, i+chunk_size)
+                future.add_done_callback(lambda p: pbar.update())
+                futures_list.append(future)
+
+            for future in futures_list:
+                result = future.result()
+                missing_paths.append(result)
+
+
+    f = open(f"CGLM_{split}_missing_paths.txt", "w")
+    
+    for i in missing_paths:
+        if i is not None:
+            print(f"{i[0]},{i[1]}", file=f)
+    
+    f.close()
+
+if __name__ == "__main__":
+    for split in ['train', 'test', 'pretrain', 'pretest', 'preval', 'cls_inc', 'data_inc']:
+        print(split)
+        try:
+            list_missing(split)
+        except Exception as e:
+            print(e)
+            continue

--- a/src/sequential_zipper.py
+++ b/src/sequential_zipper.py
@@ -1,0 +1,135 @@
+import os
+import argparse
+import time
+import zipfile
+from io import BytesIO
+
+from dataloader import H5Dataset
+# from concurrent.futures import ThreadPoolExecutor as Pool
+from concurrent.futures import ProcessPoolExecutor as Pool
+from tqdm import tqdm
+
+def compress_single_zip(src_list: list, archive_list: list, target_zip: str, in_memory: bool = True) -> None:
+    """
+    Zips the files in the src_list into a single zip file.
+
+    Args:
+        src_list: A list of files to be zipped.
+        archive_list: A list of archive names for the files in src_list.
+        target_zip: The name of the zip file to be created.
+        in_memory: Whether to create the zip file in memory first or on disk directly.
+            (this uses more memory but is faster because it avoids incremental writes to disk)
+
+    Returns:
+        None
+    """
+    if not in_memory:
+        with zipfile.ZipFile(target_zip, 'w') as zip_ref:
+            for file, arc_name in zip(src_list, archive_list):
+                zip_ref.write(file, arc_name)
+    else:
+        memory_zip = BytesIO()
+        with zipfile.ZipFile(memory_zip, 'w') as zip_ref:
+            for file, arc_name in zip(src_list, archive_list):
+                zip_ref.write(file, arc_name)
+        with open(target_zip, 'wb') as f:
+            f.write(memory_zip.getvalue())
+
+def extract_single_zip(directory: str, zip_file: str) -> None:
+    zip_path = os.path.join(directory, zip_file)
+    output_dir = os.path.join(
+        directory, os.path.splitext(zip_file)[0])
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(output_dir)
+
+
+def zip_data_files(dataset, num_images, num_chunks, target_dir, parallel=True):
+    """
+    Zips the first N images from the dataset into M zip files.
+    """
+
+    os.makedirs(target_dir, exist_ok=True)
+    
+    # Get the list of file paths to be zipped
+    src_list = [
+        os.path.join(dataset.directory, "data", p.decode('utf-8').strip())
+        for p in dataset.image_paths[:num_images]
+    ]
+
+    # Get the corresponding list of archive paths (relative to the dataset directory)
+    archive_list = [
+        p.decode('utf-8').strip()
+        for p in dataset.image_paths[:num_images]
+    ]
+
+    chunk_size = num_images // num_chunks
+    if parallel:
+        with Pool() as executor, tqdm(total=num_chunks) as pbar:
+            futures_list = []
+            for i in range(num_chunks):
+                start = i * chunk_size
+                end = (i + 1) * chunk_size
+                target_zip = os.path.join(target_dir, f"images_{i:04}.zip")
+                future = executor.submit(compress_single_zip, src_list[start:end], archive_list[start:end], target_zip)
+                future.add_done_callback(lambda p: pbar.update(1))
+                futures_list.append(future)
+
+            # Wait for all tasks to complete
+            for future in futures_list:
+                future.result()
+    else:
+        for i in range(num_chunks):
+            start = i * chunk_size
+            end = (i + 1) * chunk_size
+            target_zip = os.path.join(target_dir, f"images_{i:04}.zip")
+            compress_single_zip(src_list[start:end], archive_list[start:end], target_zip)
+
+def unzip_data_files(directory):
+    zip_files = [file for file in os.listdir(
+        directory) if file.endswith('.zip')]
+
+    with Pool(max_workers=8) as executor, tqdm(total=len(zip_files)) as pbar:
+        futures_list = []
+        for zip_file in zip_files:
+            # pbar.update(1)
+            # extract_single_zip(directory, zip_file)
+            future = executor.submit(extract_single_zip, directory, zip_file)
+            future.add_done_callback(lambda p: pbar.update(1))
+            futures_list.append(future)
+
+        # Wait for all tasks to complete
+        for future in futures_list:
+            future.result()
+
+
+
+if __name__ == "__main__":
+    print("""
+    This script will zip the first N images from the CLOC dataset
+    so it can be copied efficiently on the compute node for experimentation.
+
+    This script is meant to be run before any of the experiments start.
+    The experiments won't be expected to run to completion, just to N images.
+    """)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=str, default="CLOC")
+    parser.add_argument("--directory", type=str, default="/export/work/cbotos/cldatasets/CLOC")
+    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--num-images", type=int, default=300000 * 128)
+    parser.add_argument("--num-chunks", type=int, default=1024)
+    parser.add_argument("--unzip", action="store_true")
+    args = parser.parse_args()
+
+    if args.unzip:
+        unzip_data_files(args.directory)
+        exit()
+    
+    target_dir = os.path.join(args.directory, "data", "sequentially_zipped", f"first_{args.num_images:010d}_images")
+
+    dataset = H5Dataset(dataset=args.dataset, directory=args.directory, partition=args.split)
+    zip_data_files(dataset, args.num_images, args.num_chunks, target_dir, parallel=True)
+    print(f"The sequentially zipped files can be found in: {target_dir}")
+    

--- a/src/sequential_zipper.py
+++ b/src/sequential_zipper.py
@@ -5,11 +5,18 @@ import zipfile
 from io import BytesIO
 
 from dataloader import H5Dataset
-# from concurrent.futures import ThreadPoolExecutor as Pool
-from concurrent.futures import ProcessPoolExecutor as Pool
+from concurrent.futures import ThreadPoolExecutor as Pool
+# from concurrent.futures import ProcessPoolExecutor as Pool
 from tqdm import tqdm
 
-def compress_single_zip(src_list: list, archive_list: list, target_zip: str, in_memory: bool = True) -> None:
+def compress_single_zip(
+        dataset: H5Dataset, 
+        start_idx: int, 
+        end_idx: int, 
+        target_zip: str, 
+        in_memory: bool = True, 
+        verbose: bool = True
+    ) -> None:
     """
     Zips the files in the src_list into a single zip file.
 
@@ -23,6 +30,19 @@ def compress_single_zip(src_list: list, archive_list: list, target_zip: str, in_
     Returns:
         None
     """
+
+    # Get the list of file paths to be zipped
+    src_list = [
+        os.path.join(dataset.directory, "data", p.decode('utf-8').strip())
+        for p in dataset.image_paths[start_idx:end_idx]
+    ]
+
+    # Get the corresponding list of archive paths (relative to the dataset directory)
+    archive_list = [
+        p.decode('utf-8').strip()
+        for p in dataset.image_paths[start_idx:end_idx]
+    ]
+
     if not in_memory:
         with zipfile.ZipFile(target_zip, 'w') as zip_ref:
             for file, arc_name in zip(src_list, archive_list):
@@ -30,20 +50,23 @@ def compress_single_zip(src_list: list, archive_list: list, target_zip: str, in_
     else:
         memory_zip = BytesIO()
         with zipfile.ZipFile(memory_zip, 'w') as zip_ref:
-            for file, arc_name in zip(src_list, archive_list):
-                zip_ref.write(file, arc_name)
+            if verbose:
+                for file, arc_name in tqdm(zip(src_list, archive_list), total=len(src_list), desc=target_zip, leave=False):
+                    zip_ref.write(file, arc_name)
+            else:
+                for file, arc_name in zip(src_list, archive_list):
+                    zip_ref.write(file, arc_name)
         with open(target_zip, 'wb') as f:
             f.write(memory_zip.getvalue())
 
-def extract_single_zip(directory: str, zip_file: str) -> None:
-    zip_path = os.path.join(directory, zip_file)
-    output_dir = os.path.join(
-        directory, os.path.splitext(zip_file)[0])
 
-    os.makedirs(output_dir, exist_ok=True)
+
+def extract_single_zip(directory: str, zip_file: str) -> None:
+    assert zip_file.endswith(".zip")
+    zip_path = os.path.join(directory, zip_file)
 
     with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-        zip_ref.extractall(output_dir)
+        zip_ref.extractall(directory)
 
 
 def zip_data_files(dataset, num_images, num_chunks, target_dir, parallel=True):
@@ -53,27 +76,17 @@ def zip_data_files(dataset, num_images, num_chunks, target_dir, parallel=True):
 
     os.makedirs(target_dir, exist_ok=True)
     
-    # Get the list of file paths to be zipped
-    src_list = [
-        os.path.join(dataset.directory, "data", p.decode('utf-8').strip())
-        for p in dataset.image_paths[:num_images]
-    ]
-
-    # Get the corresponding list of archive paths (relative to the dataset directory)
-    archive_list = [
-        p.decode('utf-8').strip()
-        for p in dataset.image_paths[:num_images]
-    ]
 
     chunk_size = num_images // num_chunks
     if parallel:
-        with Pool() as executor, tqdm(total=num_chunks) as pbar:
+        with Pool(max_workers=8) as executor, tqdm(total=num_chunks) as pbar:
             futures_list = []
             for i in range(num_chunks):
                 start = i * chunk_size
                 end = (i + 1) * chunk_size
-                target_zip = os.path.join(target_dir, f"images_{i:04}.zip")
-                future = executor.submit(compress_single_zip, src_list[start:end], archive_list[start:end], target_zip)
+                target_zip = os.path.join(target_dir, f"images_{i:04}_of_{num_chunks}.zip")
+                future = executor.submit(compress_single_zip, dataset, start, end, target_zip, True, True)
+                # future = executor.submit(worker_task, target_zip)
                 future.add_done_callback(lambda p: pbar.update(1))
                 futures_list.append(future)
 
@@ -81,29 +94,55 @@ def zip_data_files(dataset, num_images, num_chunks, target_dir, parallel=True):
             for future in futures_list:
                 future.result()
     else:
-        for i in range(num_chunks):
+        for i in tqdm(range(num_chunks), total=num_chunks, position=0, leave=True):
             start = i * chunk_size
             end = (i + 1) * chunk_size
-            target_zip = os.path.join(target_dir, f"images_{i:04}.zip")
-            compress_single_zip(src_list[start:end], archive_list[start:end], target_zip)
+            target_zip = os.path.join(target_dir, f"images_{i:04}_of_{num_chunks}.zip")
+            compress_single_zip(dataset, start, end, target_zip, True, True)
 
-def unzip_data_files(directory):
+def unzip_data_files(directory, parallel=True):
     zip_files = [file for file in os.listdir(
         directory) if file.endswith('.zip')]
 
-    with Pool(max_workers=8) as executor, tqdm(total=len(zip_files)) as pbar:
+    if parallel:
+        with Pool() as executor, tqdm(total=len(zip_files)) as pbar:
+            futures_list = []
+            for zip_file in zip_files:
+                # pbar.update(1)
+                # extract_single_zip(directory, zip_file)
+                future = executor.submit(extract_single_zip, directory, zip_file)
+                future.add_done_callback(lambda p: pbar.update(1))
+                futures_list.append(future)
+
+            # Wait for all tasks to complete
+            for future in futures_list:
+                future.result()
+    else:
+        for zip_file in tqdm(zip_files, total=len(zip_files), position=0, leave=True):
+            extract_single_zip(directory, zip_file)
+
+
+def worker_task(progress_bar):
+    for _ in tqdm(range(10), desc=progress_bar, leave=False):
+        time.sleep(0.1)
+
+def foo():
+    task_descriptions = [f"task {i}" for i in range(100)]
+    num_chunks = 10
+    chunk_size=20
+    target_dir = "/tmp"
+    with Pool(max_workers=3) as executor, tqdm(total=num_chunks) as pbar:
         futures_list = []
-        for zip_file in zip_files:
-            # pbar.update(1)
-            # extract_single_zip(directory, zip_file)
-            future = executor.submit(extract_single_zip, directory, zip_file)
+        for i in range(num_chunks):
+            start = i * chunk_size
+            end = (i + 1) * chunk_size
+            target_zip = os.path.join(target_dir, f"images_{i:04}_of_{num_chunks}.zip")
+            future = executor.submit(worker_task, target_zip)
             future.add_done_callback(lambda p: pbar.update(1))
             futures_list.append(future)
 
-        # Wait for all tasks to complete
         for future in futures_list:
             future.result()
-
 
 
 if __name__ == "__main__":
@@ -118,18 +157,21 @@ if __name__ == "__main__":
     parser.add_argument("--dataset", type=str, default="CLOC")
     parser.add_argument("--directory", type=str, default="/export/work/cbotos/cldatasets/CLOC")
     parser.add_argument("--split", type=str, default="train")
-    parser.add_argument("--num-images", type=int, default=300000 * 128)
+    parser.add_argument("--num-images", type=int, default=30000 * 128)
     parser.add_argument("--num-chunks", type=int, default=1024)
+    parser.add_argument("--parallel", action="store_true")
     parser.add_argument("--unzip", action="store_true")
     args = parser.parse_args()
 
     if args.unzip:
-        unzip_data_files(args.directory)
+        unzip_data_files(args.directory, parallel=args.parallel)
         exit()
     
     target_dir = os.path.join(args.directory, "data", "sequentially_zipped", f"first_{args.num_images:010d}_images")
 
     dataset = H5Dataset(dataset=args.dataset, directory=args.directory, partition=args.split)
-    zip_data_files(dataset, args.num_images, args.num_chunks, target_dir, parallel=True)
+    zip_data_files(dataset, args.num_images, args.num_chunks, target_dir, parallel=args.parallel)
     print(f"The sequentially zipped files can be found in: {target_dir}")
     
+
+    # foo()


### PR DESCRIPTION
Since the CLOC dataset is enormous (~2.4TB when decompressed) it's useful to have sequential access to the dataset, in case one cannot efficiently access all elements at will.

This script generates a sequence of zip files from the already decompressed dataset, but the zip file sequence will follow the ordering of the underlying images, therefore allowing one to implement an efficient caching operation.

Note that the script leaves the directory structure of the underlying dataset intact, so it will not conflict with the HD5 order files.